### PR TITLE
legal: compliance fixes — affiliate disclosure, page title, privacy policy

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -120,7 +120,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   </svg>
                   @audealdrop
                 </a>
-                <p>Amazon Associate — qualifying purchases earn a commission.</p>
+                <p>As an Amazon Associate I earn from qualifying purchases.</p>
               </div>
             </div>
           </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,9 +10,9 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "DealDrop — Best Deals in Australia & India",
+  title: "DealDrop — Great Deals in Australia & India",
   description:
-    "Real promo deals from Amazon AU, OzBargain, Flipkart and more. Verified prices, updated every hour. Free, no signup needed.",
+    "Real promo deals from Amazon AU, OzBargain, Flipkart and more. Updated every hour. Free, no signup needed.",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -13,15 +13,24 @@ export default function PrivacyPage() {
       <h2>Who we are</h2>
       <p>
         DealDrop is an Australian deals aggregation website operated by Rohit Ramesh Naik
-        (an individual). It collects and displays promotional deals sourced from public
-        feeds including OzBargain and Reddit r/AusDeals. We do not sell products directly.
+        (ABN: [ABN HERE]) (an individual). It collects and displays promotional deals
+        sourced from public feeds including OzBargain and Reddit r/AusDeals. We do not
+        sell products directly. Contact:{" "}
+        <a href="/contact">via our contact page</a>.
       </p>
 
       <h2>What data we collect</h2>
       <p>
-        DealDrop does <strong>not</strong> require you to create an account or provide
-        any personal information to use the site. We do not collect names, email
-        addresses, or payment information.
+        DealDrop does <strong>not</strong> require you to create an account to browse
+        deals. If you subscribe to deal alerts via our email subscription form, we collect
+        your <strong>email address</strong> using{" "}
+        <a href="https://loops.so" target="_blank" rel="noopener noreferrer">Loops</a>,
+        our email marketing provider. Your email is used solely to send you deal
+        notifications and is never sold or shared with third parties beyond Loops. You can
+        unsubscribe at any time using the link in any email we send.
+      </p>
+      <p>
+        We do not collect names or payment information.
       </p>
       <p>
         Our hosting provider (Vercel) may collect standard server logs including IP


### PR DESCRIPTION
## Summary
Addressing findings from Lex's weekly legal review. Three page-content fixes only — no logic changes.

---

### ✅ Fix 1 — Footer: exact Amazon affiliate phrase (`app/layout.tsx`)
**Before:** `Amazon Associate — qualifying purchases earn a commission.`
**After:** `As an Amazon Associate I earn from qualifying purchases.`

Amazon Associates policy and ACCC guidelines both require this exact phrase. The previous wording was non-compliant.

---

### ✅ Fix 2 — Page title: soften superlative (`app/layout.tsx`)
**Before:** `DealDrop — Best Deals in Australia & India`
**After:** `DealDrop — Great Deals in Australia & India`

Also removed `"Verified prices"` from the meta description — we can't substantiate that claim under ACL S.29 given prices come from third-party feeds.

---

### ✅ Fix 3 — Privacy Policy: ABN + Loops email disclosure (`app/privacy/page.tsx`)
- Added ABN field (placeholder `[ABN HERE]` — **Rohit to fill in before merge**) and contact link to the operator section.
- Rewrote the "What data we collect" section to correctly disclose that we collect email addresses via Loops for deal alerts, including the unsubscribe right.

The previous policy stated we collect *no* personal information at all — which is factually wrong given the live EmailPopup/Loops integration. That's a Privacy Act 1988 breach.

---

### ⚠️ Action required before merge
- [ ] Rohit: replace `[ABN HERE]` with your actual ABN in `app/privacy/page.tsx`

### Out of scope for this PR
- Discount % badge source verification note (tracked separately, needs backend input)
- Instagram caption/bio changes (not a page content file)
- India/Singapore PDPA expansion (separate PR, needs scoping)

Closes findings from Lex's legal review — cc @Lex