### PR TITLE
fix: click tracking broken due to edge runtime termination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules/
 
 # Build output
 .next/
-out/
+/out/
 build/
 dist/
 

--- a/app/out/route.ts
+++ b/app/out/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest } from "next/server";
+import { db } from "@/lib/db";
 
-export const runtime = "edge";
+// Node.js runtime — edge runtime kills the worker before fire-and-forget fetch completes,
+// causing clicks to not be recorded. Node.js waits for the event loop to drain.
+export const runtime = "nodejs";
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -18,13 +21,12 @@ export async function GET(req: NextRequest) {
     return new Response("Invalid url", { status: 400 });
   }
 
-  // Fire-and-forget click tracking — don't await, don't slow the redirect
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://dealdrop.au";
-  fetch(`${siteUrl}/api/track`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ dealId }),
-  }).catch(() => {});
+  // Insert click directly — no HTTP hop, no fire-and-forget reliability issues
+  if (dealId) {
+    db.$executeRaw`
+      INSERT INTO deal_clicks (deal_id, clicked_at) VALUES (${dealId}::text, NOW())
+    `.catch(() => {});
+  }
 
   return Response.redirect(target.toString(), 302);
 }


### PR DESCRIPTION
## Problem
Zero clicks recorded since May 21 despite real traffic. Root cause: `/out/route.ts` used `runtime="edge"`.

Vercel's Edge Runtime kills the worker **immediately after returning the response**. The fire-and-forget `fetch()` to `/api/track` was being cancelled before it completed — so no clicks were ever written to the DB after the edge worker terminated.

Direct API calls to `/api/track` worked fine (confirmed), but clicks through `/out` were silently dropped.

## Fix
- Switch `/out` from `runtime="edge"` to `runtime="nodejs"` — Node.js serverless waits for the event loop to drain before terminating
- Remove the HTTP hop entirely: insert into `deal_clicks` directly via Prisma instead of calling `/api/track`. Simpler, more reliable, one less network round-trip
- Fix `.gitignore`: `out/` was matching `app/out/` — changed to `/out/` (root-level only)

## Impact
All clicks through deal cards will now be recorded correctly. Finn's weekly reports will show real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)