### PR TITLE
fix: disable Buffer auto-posting to prevent Instagram ban

### DIFF
--- a/.github/workflows/daily-deals-post.yml
+++ b/.github/workflows/daily-deals-post.yml
@@ -32,11 +32,9 @@ jobs:
       - name: Generate and queue deal post
         env:
           POST_TO_INSTAGRAM: "false"
-          POST_TO_BUFFER: "true"
+          POST_TO_BUFFER: "false"
           CLOUDINARY_CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
           CLOUDINARY_UPLOAD_PRESET: ${{ secrets.CLOUDINARY_UPLOAD_PRESET }}
-          BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
-          BUFFER_PROFILE_ID: ${{ secrets.BUFFER_PROFILE_ID }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           AFFILIATE_TAG: ${{ secrets.AFFILIATE_TAG || 'dealdrop0d5-22' }}


### PR DESCRIPTION
## Summary
- Sets `POST_TO_BUFFER: "false"` in the daily workflow
- Instagram previously banned @audealdrop for automated posting via Buffer
- Workflow now only generates images + captions and uploads them as GitHub Actions artifacts (30-day retention)
- Rohit downloads and posts manually from phone — no API posting

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` — verify it generates artifacts but does not post to Buffer or Instagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)