### PR TITLE
fix: don't fail workflow when no qualifying deals today

### DIFF
--- a/.github/workflows/daily-deals-post.yml
+++ b/.github/workflows/daily-deals-post.yml
@@ -44,8 +44,9 @@ jobs:
         run: npm run generate
       - name: Upload deal posts as artifact
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: instagram-deals-${{ github.run_number }}
           path: pipeline/camel-to-instagram/output/
           retention-days: 30
-          if-no-files-found: error
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- Changed `if-no-files-found: error` → `warn` on the artifact upload step
- Added `continue-on-error: true` to the upload step
- When the product filter finds no Instagram-worthy deals, `output/` stays empty and the run now passes silently instead of failing

## Root cause
Today's CamelCamelCamel feed had no deals in Beauty/Fashion/Tech/Gaming/Kitchen/Home/Fragrance categories above the price/discount thresholds. The filter correctly skipped everything but the workflow failed because the artifact step errored on empty output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)