### PR TITLE
fix: use Cloudinary for reel upload (Drive quota error)

### DIFF
--- a/.github/workflows/daily-deals-post.yml
+++ b/.github/workflows/daily-deals-post.yml
@@ -49,8 +49,8 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AFFILIATE_TAG: ${{ secrets.AFFILIATE_TAG || 'dealdrop0d5-22' }}
-          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
-          GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+          CLOUDINARY_CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
+          CLOUDINARY_UPLOAD_PRESET: ${{ secrets.CLOUDINARY_UPLOAD_PRESET }}
         run: npm run generate:reel
       - name: Upload deal posts as artifact
         uses: actions/upload-artifact@v4

--- a/pipeline/camel-to-instagram/generate-reel.ts
+++ b/pipeline/camel-to-instagram/generate-reel.ts
@@ -267,16 +267,16 @@ export async function generateReel(): Promise<void> {
   const captionPath = path.join(outputDir, "reel-caption.txt");
   fs.writeFileSync(captionPath, generateReelCaption(deals));
 
-  // Upload to Google Drive so it appears in your Drive folder on Android
+  // Upload to Cloudinary — get a public URL you can open on Android to download
   try {
-    const { uploadToGoogleDrive } = await import("./upload-drive");
-    const driveUrl = await uploadToGoogleDrive(videoPath);
-    if (driveUrl) {
-      fs.writeFileSync(path.join(outputDir, "reel-drive-url.txt"), driveUrl);
-      console.log("[generate-reel] Google Drive link:", driveUrl);
+    const { uploadVideoToCloudinary } = await import("./cloudinary");
+    const cloudUrl = await uploadVideoToCloudinary(videoPath);
+    if (cloudUrl) {
+      fs.writeFileSync(path.join(outputDir, "reel-url.txt"), cloudUrl);
+      console.log("[generate-reel] Download on Android:", cloudUrl);
     }
   } catch (err) {
-    console.warn("[generate-reel] Google Drive upload failed (reel still saved locally):", err);
+    console.warn("[generate-reel] Cloudinary upload failed (reel still in artifact):", err);
   }
 
   await saveReelPost(deals);


### PR DESCRIPTION
## Problem
Google Drive service accounts have no storage quota — uploads fail with "Service Accounts do not have storage quota" for regular Drive folders.

## Fix
Switch to Cloudinary video upload (already configured). After reel is generated:
1. Uploads to Cloudinary
2. Writes public URL to `output/reel/reel-url.txt` in the artifact
3. Open that URL on Android → tap to download → post to Instagram

No new secrets needed — `CLOUDINARY_CLOUD_NAME` and `CLOUDINARY_UPLOAD_PRESET` already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)