### PR TITLE
fix: Google Drive upload via OAuth2 refresh token

### DIFF
--- a/.github/workflows/daily-deals-post.yml
+++ b/.github/workflows/daily-deals-post.yml
@@ -49,8 +49,10 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AFFILIATE_TAG: ${{ secrets.AFFILIATE_TAG || 'dealdrop0d5-22' }}
-          CLOUDINARY_CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
-          CLOUDINARY_UPLOAD_PRESET: ${{ secrets.CLOUDINARY_UPLOAD_PRESET }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          GOOGLE_OAUTH_REFRESH_TOKEN: ${{ secrets.GOOGLE_OAUTH_REFRESH_TOKEN }}
+          GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
         run: npm run generate:reel
       - name: Upload deal posts as artifact
         uses: actions/upload-artifact@v4

--- a/pipeline/camel-to-instagram/generate-reel.ts
+++ b/pipeline/camel-to-instagram/generate-reel.ts
@@ -267,16 +267,16 @@ export async function generateReel(): Promise<void> {
   const captionPath = path.join(outputDir, "reel-caption.txt");
   fs.writeFileSync(captionPath, generateReelCaption(deals));
 
-  // Upload to Cloudinary — get a public URL you can open on Android to download
+  // Upload to Google Drive — appears in your Drive folder on Android automatically
   try {
-    const { uploadVideoToCloudinary } = await import("./cloudinary");
-    const cloudUrl = await uploadVideoToCloudinary(videoPath);
-    if (cloudUrl) {
-      fs.writeFileSync(path.join(outputDir, "reel-url.txt"), cloudUrl);
-      console.log("[generate-reel] Download on Android:", cloudUrl);
+    const { uploadToGoogleDrive } = await import("./upload-drive");
+    const driveUrl = await uploadToGoogleDrive(videoPath);
+    if (driveUrl) {
+      fs.writeFileSync(path.join(outputDir, "reel-drive-url.txt"), driveUrl);
+      console.log("[generate-reel] Google Drive link:", driveUrl);
     }
   } catch (err) {
-    console.warn("[generate-reel] Cloudinary upload failed (reel still in artifact):", err);
+    console.warn("[generate-reel] Google Drive upload failed (reel still in artifact):", err);
   }
 
   await saveReelPost(deals);

--- a/pipeline/camel-to-instagram/get-drive-token.ts
+++ b/pipeline/camel-to-instagram/get-drive-token.ts
@@ -1,0 +1,36 @@
+/**
+ * Run once to get a Google OAuth refresh token for Drive uploads.
+ * Usage: ts-node get-drive-token.ts
+ */
+import { google } from "googleapis";
+import * as readline from "readline";
+
+const CLIENT_ID     = process.env.GOOGLE_OAUTH_CLIENT_ID!;
+const CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET!;
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error("Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET first");
+  process.exit(1);
+}
+
+const auth = new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, "urn:ietf:wg:oauth:2.0:oob");
+const url  = auth.generateAuthUrl({
+  access_type: "offline",
+  scope: ["https://www.googleapis.com/auth/drive.file"],
+  prompt: "consent",
+});
+
+console.log("\n1. Open this URL in your browser:\n");
+console.log(url);
+console.log("\n2. Sign in with your Google account and allow access.");
+console.log("3. Copy the code shown and paste it below.\n");
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+rl.question("Paste the code here: ", async (code) => {
+  rl.close();
+  const { tokens } = await auth.getToken(code.trim());
+  console.log("\n✅ Add these as GitHub secrets:\n");
+  console.log(`GOOGLE_OAUTH_CLIENT_ID     = ${CLIENT_ID}`);
+  console.log(`GOOGLE_OAUTH_CLIENT_SECRET = ${CLIENT_SECRET}`);
+  console.log(`GOOGLE_OAUTH_REFRESH_TOKEN = ${tokens.refresh_token}`);
+});

--- a/pipeline/camel-to-instagram/upload-drive.ts
+++ b/pipeline/camel-to-instagram/upload-drive.ts
@@ -3,29 +3,29 @@ import path from "path";
 import { google } from "googleapis";
 
 /**
- * Upload a file to Google Drive using a service account.
+ * Upload a file to the user's own Google Drive using OAuth2 refresh token.
  *
- * Required env vars:
- *   GOOGLE_SERVICE_ACCOUNT_JSON  — full JSON key of the service account
- *   GOOGLE_DRIVE_FOLDER_ID       — ID of the Drive folder shared with the service account
+ * Required env vars (GitHub secrets):
+ *   GOOGLE_OAUTH_CLIENT_ID      — OAuth2 client ID
+ *   GOOGLE_OAUTH_CLIENT_SECRET  — OAuth2 client secret
+ *   GOOGLE_OAUTH_REFRESH_TOKEN  — long-lived refresh token from user's Google account
+ *   GOOGLE_DRIVE_FOLDER_ID      — ID of the target Drive folder
  */
 export async function uploadToGoogleDrive(filePath: string): Promise<string> {
-  const credJson = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
-  const folderId = process.env.GOOGLE_DRIVE_FOLDER_ID;
+  const clientId     = process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  const refreshToken = process.env.GOOGLE_OAUTH_REFRESH_TOKEN;
+  const folderId     = process.env.GOOGLE_DRIVE_FOLDER_ID;
 
-  if (!credJson || !folderId) {
-    console.warn("[drive] GOOGLE_SERVICE_ACCOUNT_JSON or GOOGLE_DRIVE_FOLDER_ID not set — skipping");
+  if (!clientId || !clientSecret || !refreshToken || !folderId) {
+    console.warn("[drive] Missing OAuth env vars — skipping Google Drive upload");
     return "";
   }
 
-  const creds = JSON.parse(credJson);
-  const auth = new google.auth.GoogleAuth({
-    credentials: creds,
-    scopes: ["https://www.googleapis.com/auth/drive.file"],
-  });
+  const auth = new google.auth.OAuth2(clientId, clientSecret);
+  auth.setCredentials({ refresh_token: refreshToken });
 
   const drive = google.drive({ version: "v3", auth });
-  const fileName = path.basename(filePath);
   const today = new Date().toISOString().slice(0, 10);
   const displayName = `DealDrop_Reel_${today}.mp4`;
 
@@ -43,15 +43,7 @@ export async function uploadToGoogleDrive(filePath: string): Promise<string> {
     fields: "id, webViewLink",
   });
 
-  const fileId = res.data.id!;
   const viewLink = res.data.webViewLink!;
-
-  // Make it viewable by anyone with the link so you can open on Android
-  await drive.permissions.create({
-    fileId,
-    requestBody: { role: "reader", type: "anyone" },
-  });
-
-  console.log(`[drive] Uploaded! Open on Android: ${viewLink}`);
+  console.log(`[drive] Uploaded! View on Android: ${viewLink}`);
   return viewLink;
 }


### PR DESCRIPTION
## Problem
Service accounts have no storage quota on personal Google Drive.

## Fix
Use OAuth2 with the user's own Google account refresh token instead.
File appears directly in their Drive folder on Android.

## Setup (one time)
Run locally after merging:
```
GOOGLE_OAUTH_CLIENT_ID=xxx GOOGLE_OAUTH_CLIENT_SECRET=xxx npx ts-node get-drive-token.ts
```
Follow the prompts → add 3 secrets to GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)