### PR TITLE
feat: upload reel caption to Google Drive alongside video

### DIFF
--- a/pipeline/camel-to-instagram/generate-reel.ts
+++ b/pipeline/camel-to-instagram/generate-reel.ts
@@ -267,14 +267,19 @@ export async function generateReel(): Promise<void> {
   const captionPath = path.join(outputDir, "reel-caption.txt");
   fs.writeFileSync(captionPath, generateReelCaption(deals));
 
-  // Upload to Google Drive — appears in your Drive folder on Android automatically
+  // Upload reel + caption to Google Drive — appears on Android automatically
   try {
-    const { uploadToGoogleDrive } = await import("./upload-drive");
+    const { uploadToGoogleDrive, uploadTextToGoogleDrive } = await import("./upload-drive");
+    const today = new Date().toISOString().slice(0, 10);
+
     const driveUrl = await uploadToGoogleDrive(videoPath);
     if (driveUrl) {
       fs.writeFileSync(path.join(outputDir, "reel-drive-url.txt"), driveUrl);
       console.log("[generate-reel] Google Drive link:", driveUrl);
     }
+
+    const caption = generateReelCaption(deals);
+    await uploadTextToGoogleDrive(caption, `DealDrop_Caption_${today}.txt`);
   } catch (err) {
     console.warn("[generate-reel] Google Drive upload failed (reel still in artifact):", err);
   }

--- a/pipeline/camel-to-instagram/upload-drive.ts
+++ b/pipeline/camel-to-instagram/upload-drive.ts
@@ -47,3 +47,23 @@ export async function uploadToGoogleDrive(filePath: string): Promise<string> {
   console.log(`[drive] Uploaded! View on Android: ${viewLink}`);
   return viewLink;
 }
+
+export async function uploadTextToGoogleDrive(content: string, fileName: string): Promise<void> {
+  const clientId     = process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  const refreshToken = process.env.GOOGLE_OAUTH_REFRESH_TOKEN;
+  const folderId     = process.env.GOOGLE_DRIVE_FOLDER_ID;
+
+  if (!clientId || !clientSecret || !refreshToken || !folderId) return;
+
+  const auth = new google.auth.OAuth2(clientId, clientSecret);
+  auth.setCredentials({ refresh_token: refreshToken });
+  const drive = google.drive({ version: "v3", auth });
+
+  const { Readable } = await import("stream");
+  await drive.files.create({
+    requestBody: { name: fileName, parents: [folderId] },
+    media: { mimeType: "text/plain", body: Readable.from([content]) },
+  });
+  console.log(`[drive] Caption uploaded: ${fileName}`);
+}


### PR DESCRIPTION
## Summary
- After generating `reel.mp4`, also uploads `DealDrop_Caption_YYYY-MM-DD.txt` to the same Drive folder
- Open Google Drive on Android — both the video and caption are ready, copy-paste the caption when posting to Instagram

## Files changed
- `pipeline/camel-to-instagram/upload-drive.ts` — added `uploadTextToGoogleDrive()` function
- `pipeline/camel-to-instagram/generate-reel.ts` — calls it after video upload

## Test plan
- [ ] Run `npm run generate:reel` with Drive env vars set
- [ ] Confirm `DealDrop_Reel_YYYY-MM-DD.mp4` appears in Drive folder
- [ ] Confirm `DealDrop_Caption_YYYY-MM-DD.txt` appears alongside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)