### PR TITLE
fix: update weekly-reel workflow with music, Drive, Cloudinary, TryPost.it

### DIFF
--- a/.github/workflows/weekly-reel.yml
+++ b/.github/workflows/weekly-reel.yml
@@ -1,12 +1,15 @@
 name: Weekly Reels Post
 on:
   schedule:
-    - cron: "0 9 * * 0"
+    - cron: "0 22 * * *"
   workflow_dispatch:
 
 jobs:
   generate-reel:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pipeline/camel-to-instagram
     steps:
       - uses: actions/checkout@v4
 
@@ -14,27 +17,47 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: pipeline/camel-to-instagram/package.json
 
       - name: Install FFmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: sudo apt-get install -y ffmpeg
 
       - name: Install dependencies
-        working-directory: pipeline/camel-to-instagram
         run: npm install
 
       - name: Install Puppeteer browser
-        working-directory: pipeline/camel-to-instagram
         run: npx puppeteer browsers install chrome
 
+      - name: Download background music
+        continue-on-error: true
+        env:
+          BGMUSIC_URL: ${{ secrets.BGMUSIC_URL }}
+        run: |
+          if [ -n "$BGMUSIC_URL" ]; then
+            curl -fsSL "$BGMUSIC_URL" -o templates/bg-music.mp3 && echo "Background music downloaded" || echo "Music download failed — reel will be silent"
+          else
+            echo "BGMUSIC_URL not set — reel will be silent"
+          fi
+
       - name: Generate reel
-        working-directory: pipeline/camel-to-instagram
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: npx ts-node generate-reel.ts
+          AFFILIATE_TAG: ${{ secrets.AFFILIATE_TAG || 'dealdrop0d5-22' }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          GOOGLE_OAUTH_REFRESH_TOKEN: ${{ secrets.GOOGLE_OAUTH_REFRESH_TOKEN }}
+          GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+          CLOUDINARY_CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
+          CLOUDINARY_UPLOAD_PRESET: ${{ secrets.CLOUDINARY_UPLOAD_PRESET }}
+          TRYPOST_API_TOKEN: ${{ secrets.TRYPOST_API_TOKEN }}
+        run: npm run generate:reel
 
       - name: Upload reel artifact
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
-          name: weekly-reel-${{ github.run_number }}
+          name: reel-${{ github.run_number }}
           path: pipeline/camel-to-instagram/output/reel/
-          retention-days: 7
+          retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
The dedicated reel workflow (`weekly-reel.yml`) was missing all the integrations added in PR #83. This brings it in sync:

- Background music download step (BGMUSIC_URL)
- Google Drive upload (GOOGLE_OAUTH_* secrets)
- Cloudinary upload for public URL
- TryPost.it auto-publish (TRYPOST_API_TOKEN)
- Changed cron to `0 22 * * *` (daily 8am AEST, same as daily workflow)

## Test plan
- [ ] Merge and trigger via workflow_dispatch
- [ ] Confirm music downloads, reel generates with audio
- [ ] Confirm TryPost.it post appears scheduled in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)