### PR TITLE
feat: discount % filter (10%+, 25%+, 50%+)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import DealCard from "@/components/DealCard";
 import SearchBar from "@/components/SearchBar";
 import CategoryFilter from "@/components/CategoryFilter";
+import DiscountFilter from "@/components/DiscountFilter";
 import SortSelector from "@/components/SortSelector";
 import Pagination from "@/components/Pagination";
 import TopDealSection from "@/components/TopDealSection";
@@ -13,7 +14,7 @@ import NewsletterSection from "@/components/NewsletterSection";
 import type { Deal } from "@/lib/types";
 
 interface PageProps {
-  searchParams: { q?: string; category?: string; sort?: string; page?: string; limit?: string; country?: string };
+  searchParams: { q?: string; category?: string; sort?: string; page?: string; limit?: string; country?: string; minDiscount?: string };
 }
 
 function getOrderBy(sort: string) {
@@ -33,11 +34,13 @@ async function getDeals(
   page = 1,
   limit = 24,
   country?: string,
+  minDiscount?: number,
 ): Promise<{ deals: Deal[]; total: number }> {
   const where = {
     isActive: true,
-    ...(category ? { category } : {}),
-    ...(country  ? { country }  : {}),
+    ...(category    ? { category }                           : {}),
+    ...(country     ? { country }                            : {}),
+    ...(minDiscount ? { discountPct: { gte: minDiscount } }  : {}),
     ...(search
       ? {
           OR: [
@@ -180,15 +183,16 @@ async function getAllTimeLows(country?: string): Promise<Deal[]> {
 }
 
 export default async function HomePage({ searchParams }: PageProps) {
-  const page    = Math.max(1, parseInt(searchParams.page  ?? "1",  10));
-  const limit   = Math.min(96, Math.max(12, parseInt(searchParams.limit ?? "24", 10)));
-  const sort    = searchParams.sort    ?? "newest";
-  const country = searchParams.country;
+  const page        = Math.max(1, parseInt(searchParams.page  ?? "1",  10));
+  const limit       = Math.min(96, Math.max(12, parseInt(searchParams.limit ?? "24", 10)));
+  const sort        = searchParams.sort    ?? "newest";
+  const country     = searchParams.country;
+  const minDiscount = searchParams.minDiscount ? parseInt(searchParams.minDiscount, 10) : undefined;
   // country is a display mode, not a search filter — sections stay visible when it's set
-  const isFiltered = !!(searchParams.q || searchParams.category);
+  const isFiltered = !!(searchParams.q || searchParams.category || minDiscount);
 
   const [{ deals, total }, stats, topDeals, endingSoon, allTimeLows, indiaDeals] = await Promise.all([
-    getDeals(searchParams.q, searchParams.category, sort, page, limit, country),
+    getDeals(searchParams.q, searchParams.category, sort, page, limit, country, minDiscount),
     getSiteStats(country),
     isFiltered ? Promise.resolve([]) : getTopDeals(country),
     isFiltered ? Promise.resolve([]) : getEndingSoon(country),
@@ -255,13 +259,16 @@ export default async function HomePage({ searchParams }: PageProps) {
         </div>
       </div>
 
-      {/* ── Search + Sort ── */}
+      {/* ── Search + Sort + Discount Filter ── */}
       <div className="flex flex-col sm:flex-row gap-3">
         <Suspense>
           <SearchBar />
         </Suspense>
         <Suspense>
           <SortSelector current={sort} />
+        </Suspense>
+        <Suspense>
+          <DiscountFilter />
         </Suspense>
       </div>
 

--- a/components/DiscountFilter.tsx
+++ b/components/DiscountFilter.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+import clsx from "clsx";
+
+const OPTIONS = [
+  { label: "10%+",  value: "10"  },
+  { label: "25%+",  value: "25"  },
+  { label: "50%+",  value: "50"  },
+];
+
+export default function DiscountFilter() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const active = params.get("minDiscount") ?? "";
+
+  const toggle = (value: string) => {
+    const next = new URLSearchParams(params.toString());
+    if (active === value) next.delete("minDiscount");
+    else next.set("minDiscount", value);
+    next.delete("page");
+    startTransition(() => router.push(`/?${next.toString()}`));
+  };
+
+  return (
+    <div className={clsx("flex items-center gap-2", isPending && "opacity-50 pointer-events-none")}>
+      <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide shrink-0">Off</span>
+      {OPTIONS.map(({ label, value }) => (
+        <button
+          key={value}
+          onClick={() => toggle(value)}
+          className={clsx(
+            "rounded-full border px-3 py-1.5 text-sm font-bold transition-all duration-150 shadow-sm shrink-0",
+            active === value
+              ? "bg-red-500 text-white border-red-500 shadow-red-200 shadow-md"
+              : "bg-red-50 text-red-600 border-red-100 hover:bg-red-100"
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `DiscountFilter` component: pill toggles for 10%+, 25%+, 50%+ off
- Wired into `getDeals()` — adds `discountPct: { gte: minDiscount }` Prisma filter when active
- `isFiltered` flag updated so hero/sections hide when a discount filter is active
- Renders in the search+sort row alongside `SearchBar` and `SortSelector`

## Test plan
- [ ] Visit homepage — filter pills appear next to search
- [ ] Click 50%+ — URL gets `?minDiscount=50`, grid shows only ≥50% off deals
- [ ] Click same pill again — filter clears
- [ ] Combine with category filter / search — both params co-exist
- [ ] Page resets on filter change (page param deleted by toggle logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)