### PR TITLE
feat: last refreshed indicator in header

### DIFF
--- a/app/api/last-updated/route.ts
+++ b/app/api/last-updated/route.ts
@@ -1,0 +1,8 @@
+import { db } from "@/lib/db";
+
+export const revalidate = 300;
+
+export async function GET() {
+  const latest = await db.deal.findFirst({ orderBy: { createdAt: "desc" }, select: { createdAt: true } });
+  return Response.json({ updatedAt: latest?.createdAt ?? null });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 import EmailPopup from "@/components/EmailPopup";
 import CountryToggle from "@/components/CountryToggle";
+import LastRefreshed from "@/components/LastRefreshed";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -54,6 +55,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
               </span>
               <span className="text-xs text-gray-500 font-medium hidden sm:block">Live</span>
+              <LastRefreshed />
             </div>
           </div>
         </header>

--- a/components/LastRefreshed.tsx
+++ b/components/LastRefreshed.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { useEffect, useState } from "react";
+
+function relativeTime(date: Date): string {
+  const mins = Math.floor((Date.now() - date.getTime()) / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default function LastRefreshed() {
+  const [label, setLabel] = useState<string | null>(null);
+
+  useEffect(() => {
+    let updatedAt: Date | null = null;
+
+    const tick = () => {
+      if (updatedAt) setLabel(relativeTime(updatedAt));
+    };
+
+    fetch("/api/last-updated")
+      .then((r) => r.json())
+      .then(({ updatedAt: ua }: { updatedAt: string | null }) => {
+        if (ua) { updatedAt = new Date(ua); tick(); }
+      })
+      .catch(() => {});
+
+    const id = setInterval(tick, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!label) return null;
+
+  return (
+    <span className="text-xs text-gray-400 font-medium hidden sm:block">
+      Updated {label}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/api/last-updated` route queries DB for most recent deal `createdAt` (5 min server cache)
- New `LastRefreshed` client component fetches on mount, ticks every 60s to update relative time
- Displays as "Updated Xm ago" next to the existing Live badge in the header (hidden on mobile)
- Email capture (4.1) was already fully implemented — EmailPopup + NewsletterSection + /api/subscribe → Loops.so

## Test plan
- [ ] Load homepage — header shows "Updated Xm ago" (appears after hydration)
- [ ] Verify it shows alongside the green Live dot
- [ ] Hidden on mobile (< sm breakpoint)
- [ ] Stays hidden if DB query fails (no error thrown to user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)