### PR TITLE
feat: consistent DealDrop AU branding + sitemap /india-deals

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,9 +2,9 @@ import { ShieldCheck, Clock, Zap, Globe, TrendingUp, Heart } from "lucide-react"
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "About DealDrop — Real Deals from Australia & India",
+  title: "About DealDrop AU — Real Deals from Australia & India",
   description:
-    "DealDrop is an independent deal aggregator tracking Amazon AU, OzBargain, Flipkart and more. Built by Rohit Ramesh Naik.",
+    "DealDrop AU is an independent deal aggregator tracking Amazon AU, OzBargain, Flipkart and more. Built by Rohit Ramesh Naik.",
 };
 
 const HOW_IT_WORKS = [

--- a/app/deals/[slug]/page.tsx
+++ b/app/deals/[slug]/page.tsx
@@ -58,12 +58,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const titleParts = [deal.title];
   if (discountStr) titleParts.push(discountStr);
   if (priceStr)    titleParts.push(priceStr);
-  const title = titleParts.join(" — ") + " | DealDrop";
+  const title = titleParts.join(" — ") + " | DealDrop AU";
 
   const description = [
     discountStr && priceStr
       ? `${deal.title} is ${discountStr} at ${priceStr}.`
-      : `${deal.title} — great deal spotted on DealDrop.`,
+      : `${deal.title} — great deal spotted on DealDrop AU.`,
     deal.description ? deal.description.slice(0, 120) : "",
     "Verified deal, updated automatically.",
   ].filter(Boolean).join(" ");

--- a/app/instagram/page.tsx
+++ b/app/instagram/page.tsx
@@ -2,8 +2,8 @@ import { db } from "@/lib/db";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "DealDrop — Latest Instagram Deals",
-  description: "All deals featured on our Instagram, updated daily. Best Amazon AU price drops.",
+  title: "DealDrop AU — Latest Instagram Deals",
+  description: "All deals featured on DealDrop AU's Instagram, updated daily. Best Amazon AU price drops.",
 };
 
 export const revalidate = 0;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -122,7 +122,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </div>
 
             <div className="border-t border-gray-100 pt-6 flex flex-col sm:flex-row items-center justify-between gap-3 text-xs text-gray-400">
-              <p>© {new Date().getFullYear()} DealDrop. Free to use — no subscription required.</p>
+              <p>© {new Date().getFullYear()} DealDrop AU. Free to use — no subscription required.</p>
               <div className="flex items-center gap-4">
                 <a href="https://instagram.com/audealdrop" target="_blank" rel="noopener noreferrer"
                    className="flex items-center gap-1.5 hover:text-pink-500 transition-colors">

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy — DealDrop",
+  title: "Privacy Policy — DealDrop AU",
 };
 
 export default function PrivacyPage() {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,9 +7,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = "https://dealdrop.au";
 
   const staticPages: MetadataRoute.Sitemap = [
-    { url: baseUrl,                changeFrequency: "hourly",  priority: 1.0, lastModified: new Date() },
-    { url: `${baseUrl}/instagram`, changeFrequency: "hourly",  priority: 0.9, lastModified: new Date() },
-    { url: `${baseUrl}/about`,     changeFrequency: "monthly", priority: 0.4, lastModified: new Date() },
+    { url: baseUrl,                  changeFrequency: "hourly",  priority: 1.0, lastModified: new Date() },
+    { url: `${baseUrl}/india-deals`, changeFrequency: "hourly",  priority: 0.9, lastModified: new Date() },
+    { url: `${baseUrl}/instagram`,   changeFrequency: "hourly",  priority: 0.8, lastModified: new Date() },
+    { url: `${baseUrl}/about`,       changeFrequency: "monthly", priority: 0.4, lastModified: new Date() },
     { url: `${baseUrl}/contact`,   changeFrequency: "yearly",  priority: 0.2, lastModified: new Date() },
     { url: `${baseUrl}/privacy`,   changeFrequency: "monthly", priority: 0.2, lastModified: new Date() },
     { url: `${baseUrl}/terms`,     changeFrequency: "monthly", priority: 0.2, lastModified: new Date() },

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms of Use — DealDrop",
+  title: "Terms of Use — DealDrop AU",
 };
 
 export default function TermsPage() {


### PR DESCRIPTION
## Summary
- All page `<title>` tags updated to "DealDrop AU": about, privacy, terms, instagram, deal slug pages, footer copyright
- Deal slug meta description: "on DealDrop" → "on DealDrop AU"
- Sitemap: added `/india-deals` (priority 0.9, hourly), reprioritised `/instagram` from 0.9 → 0.8

## Why
Priority 5 from feedback: consistently own the AU identity vs dealdrop.com (US competitor). Search results should always show "DealDrop AU" not just "DealDrop".

## Test plan
- [ ] Check `<title>` on /about, /privacy, /terms, /instagram in browser devtools
- [ ] Check `<title>` on any /deals/[slug] page
- [ ] Visit `/sitemap.xml` — confirm /india-deals is listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)