### PR TITLE
fix: India deals leaking into AU Top Deals Today section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -94,7 +94,7 @@ async function getTopDeals(country?: string): Promise<Deal[]> {
     // India: lower minimum (15%) — fewer extreme discounts; higher cap (90%) — fashion/electronics
     // AU: strict 40–75% range to weed out fake RRP
     discountPct: { gte: isIndia ? 15 : 40, lte: isIndia ? 90 : 75 },
-    ...(country ? { country } : {}),
+    country: country ?? "AU",
   };
   // Fetch extra so we have headroom after filtering promo deals
   const rows = await db.deal.findMany({
@@ -150,7 +150,7 @@ async function getEndingSoon(country?: string): Promise<Deal[]> {
     where: {
       isActive: true,
       expiresAt: { not: null, lte: cutoff, gte: new Date() },
-      ...(country ? { country } : {}),
+      country: country ?? "AU",
     },
     orderBy: { expiresAt: "asc" },
     take: 4,


### PR DESCRIPTION
## Bug
`getTopDeals()` and `getEndingSoon()` used `...(country ? { country } : {})`, which omits the country filter entirely when no `?country` param is set. India deals (country = "IN") were meeting the discount threshold and showing up in the AU homepage sections.

## Fix
Replace with `country: country ?? "AU"` — defaults to AU when no country toggle is active.

## Test plan
- [ ] Homepage (no ?country param) — Top Deals Today shows only AU deals
- [ ] ?country=IN — Top Deals Today shows only IN deals
- [ ] India Deals section below still shows IN deals (unaffected — uses getIndiaDealsPick which always filters country = "IN")

🤖 Generated with [Claude Code](https://claude.com/claude-code)